### PR TITLE
Custom CV

### DIFF
--- a/src/ppscore/calculation.py
+++ b/src/ppscore/calculation.py
@@ -1,8 +1,10 @@
 from sklearn import tree
 from sklearn import preprocessing
+from sklearn.dummy import DummyRegressor, DummyClassifier
 from sklearn.model_selection import cross_val_score
-from sklearn.metrics import mean_absolute_error, f1_score
-
+from sklearn.metrics import f1_score
+from sklearn.compose import make_column_transformer, ColumnTransformer
+import numpy as np
 import pandas as pd
 from pandas.api.types import (
     is_numeric_dtype,
@@ -14,6 +16,9 @@ from pandas.api.types import (
 )
 
 # if the number is 4, then it is possible to detect patterns when there are at least 4 times the same observation. If the limit is increased, the minimum observations also increase. This is important, because this is the limit when sklearn will throw an error which will lead to a score of 0 if we catch it
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import OneHotEncoder
+
 CV_ITERATIONS = 4
 
 RANDOM_SEED = 587136
@@ -29,21 +34,18 @@ RANDOM_SEED = 587136
 NUMERIC_AS_CATEGORIC_BREAKPOINT = 15
 
 
-def _calculate_model_cv_score_(df, target, feature, metric, model, **kwargs):
+def _calculate_model_cv_score_(df, target, feature, metric, model, cv, **kwargs):
     "Calculates the mean model score based on cross-validation"
     # Sources about the used methods:
     # https://scikit-learn.org/stable/modules/tree.html
     # https://scikit-learn.org/stable/modules/cross_validation.html
     # https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_val_score.html
 
-    # shuffle the rows - this is important for crossvalidation
-    # because the crossvalidation just takes the first n lines
-    # if there is a strong pattern in the rows eg 0,0,0,0,1,1,1,1
-    # then this will lead to problems because the first cv sees mostly 0 and the later 1
-    # this approach might be wrong for timeseries because it might leak information
-    df = df.sample(frac=1, random_state=RANDOM_SEED, replace=False)
-
     # preprocess target
+    # TODO: this has a risk of leaking information if a target encoder were to be used, or misleading a
+    # TODO: tree if some classes are not observed in some training folds
+    # TODO: we need to make pre-processing a part of CV pipeline
+
     if df[target].dtype == object:
         le = preprocessing.LabelEncoder()
         df[target] = le.fit_transform(df[target])
@@ -52,24 +54,33 @@ def _calculate_model_cv_score_(df, target, feature, metric, model, **kwargs):
         target_series = df[target]
 
     # preprocess feature
+    preprocess = None
     if df[feature].dtype == object:
-        one_hot_encoder = preprocessing.OneHotEncoder()
-        sparse_matrix = one_hot_encoder.fit_transform(df[feature].values.reshape(-1, 1))
-        feature_df = sparse_matrix
-    else:
-        # reshaping needed because there is only 1 feature
-        feature_df = df[feature].values.reshape(-1, 1)
+        # Dealing with categorical feature here here:
+        preprocess = ColumnTransformer(transformers = [('ct',OneHotEncoder(),[feature])])
 
-    # Crossvalidation is stratifiedKFold for classification, KFold for regression
+    # reshaping needed because there is only 1 feature: coerce to DataFrame
+    feature_df = df[feature].to_frame()
+
+    if preprocess is None:
+        pipeline_model = model
+    else:
+        pipeline_model = make_pipeline(preprocess, model)
+
+    # Pull the groups out if passed
+    groups = kwargs.get('groups', None)
+
+    # Run crossvalidation with the CV specified
     scores = cross_val_score(
-        model, feature_df, target_series, cv=CV_ITERATIONS, scoring=metric
+        pipeline_model, feature_df, target_series, cv=cv, scoring=metric,
+        groups=groups
     )
 
     return scores.mean()
 
 
 def _normalized_mae_score(model_mae, naive_mae):
-    "Normalizes the model MAE score, given the baseline score"
+    """Normalizes the model MAE score, given the baseline score"""
     # # Value range of MAE is [0, infinity), 0 is best
     # 10, 5 >> 0 because worse than naive
     # 10, 20 >> 0.5
@@ -80,17 +91,28 @@ def _normalized_mae_score(model_mae, naive_mae):
         return 1 - (model_mae / naive_mae)
 
 
-def _mae_normalizer(df, y, model_score):
-    "In case of MAE, calculates the baseline score for y and derives the PPS."
+def _mae_normalizer(df, y, model_score, cv, **kwargs):
+    """
+    In case of MAE, calculates the baseline score for y and derives the PPS.
+
+    """
     df["naive"] = df[y].median()
-    baseline_score = mean_absolute_error(df[y], df["naive"])  # true, pred
+    # Re-write baseline score using DummyRegressor with median strategy
+    baseline_regr = DummyRegressor(strategy="median")
+    groups = kwargs.get('groups', None)
+    baseline_scores_cv = cross_val_score(
+        baseline_regr, df, df[y], cv=cv,
+        scoring="neg_mean_absolute_error",
+        groups=groups
+    )
+    baseline_score = np.mean(np.abs(baseline_scores_cv))
 
     ppscore = _normalized_mae_score(abs(model_score), baseline_score)
     return ppscore, baseline_score
 
 
 def _normalized_f1_score(model_f1, baseline_f1):
-    "Normalizes the model F1 score, given the baseline score"
+    """Normalizes the model F1 score, given the baseline score"""
     # # F1 ranges from 0 to 1
     # # 1 is best
     # 0.5, 0.7 = 0 because worse than naive
@@ -104,11 +126,16 @@ def _normalized_f1_score(model_f1, baseline_f1):
         return f1_diff / scale_range  # 0.1/0.3 = 0.33
 
 
-def _f1_normalizer(df, y, model_score):
-    "In case of F1, calculates the baseline score for y and derives the PPS."
-    df["naive"] = df[y].value_counts().index[0]
-    baseline_score = f1_score(df[y], df["naive"], average="weighted")
-
+def _f1_normalizer(df, y, model_score, cv, **kwargs):
+    """In case of F1, calculates the baseline score for y and derives the PPS."""
+    baseline_clf = DummyClassifier(strategy="stratified")
+    groups = kwargs.get('groups', None)
+    baseline_scores_cv = cross_val_score(
+        baseline_clf, df, df[y], cv=cv,
+        scoring="f1_weighted",
+        groups=groups
+    )
+    baseline_score = baseline_scores_cv.mean()
     ppscore = _normalized_f1_score(model_score, baseline_score)
     return ppscore, baseline_score
 
@@ -148,7 +175,7 @@ TASKS = {
 
 
 def _infer_task(df, x, y):
-    "Returns str with the name of the inferred task based on the columns x and y"
+    """Returns str with the name of the inferred task based on the columns x and y"""
     if x == y:
         return "predict_itself"
 
@@ -158,7 +185,7 @@ def _infer_task(df, x, y):
     if category_count == 2:
         return "classification"
     if category_count == len(df[y]) and (
-        is_string_dtype(df[y]) or is_categorical_dtype(df[y])
+            is_string_dtype(df[y]) or is_categorical_dtype(df[y])
     ):
         return "predict_id"
     if category_count <= NUMERIC_AS_CATEGORIC_BREAKPOINT and is_numeric_dtype(df[y]):
@@ -182,7 +209,7 @@ def _infer_task(df, x, y):
 
 
 def _feature_is_id(df, x):
-    "Returns Boolean if the feature column x is an ID"
+    """Returns Boolean if the feature column x is an ID"""
     if not (is_string_dtype(df[x]) or is_categorical_dtype(df[x])):
         return False
 
@@ -215,7 +242,7 @@ def _maybe_sample(df, sample):
     return df
 
 
-def score(df, x, y, task=None, sample=5000):
+def score(df, x, y, task=None, sample=5000, cv=None, **kwargs):
     """
     Calculate the Predictive Power Score (PPS) for "x predicts y"
     The score always ranges from 0 to 1 and is data-type agnostic.
@@ -239,6 +266,8 @@ def score(df, x, y, task=None, sample=5000):
     sample : int or ``None``
         Number of rows for sampling. The sampling decreases the calculation time of the PPS.
         If ``None`` there will be no sampling.
+    cv: iterable or sklearn-compatible cv object
+        Crossvalidation strategy to be used
 
     Returns
     -------
@@ -246,6 +275,10 @@ def score(df, x, y, task=None, sample=5000):
         A dict that contains multiple fields about the resulting PPS.
         The dict enables introspection into the calculations that have been performed under the hood
     """
+
+    if cv is None:
+        # Did not pass any CV - fallback to defaults
+        cv = CV_ITERATIONS
 
     if x == y:
         task_name = "predict_itself"
@@ -277,9 +310,10 @@ def score(df, x, y, task=None, sample=5000):
         baseline_score = 0
     else:
         model_score = _calculate_model_cv_score_(
-            df, target=y, feature=x, metric=task["metric_key"], model=task["model"]
+            df, target=y, feature=x, metric=task["metric_key"], model=task["model"],
+            cv=cv, **kwargs
         )
-        ppscore, baseline_score = task["score_normalizer"](df, y, model_score)
+        ppscore, baseline_score = task["score_normalizer"](df, y, model_score, cv, **kwargs)
 
     return {
         "x": x,


### PR DESCRIPTION
This PR adds ability to use a custom sklearn-compatible CV generator, as long as it compatible with `cross_val_score`. 

I have also provided a test for `test_score_cv` that iterates over different cross-validation strategies implemented in `sklearn.model_selection`.
(branch has `regression` in the name, but I think the approach should work for both regression and classification problems)
I still need to carve time to devise a test for " feature leakage".