### PR TITLE
add option to select features and targets for computing matrix

### DIFF
--- a/src/ppscore/calculation.py
+++ b/src/ppscore/calculation.py
@@ -298,7 +298,7 @@ def score(df, x, y, task=None, sample=5000):
 #    pass
 
 
-def matrix(df, output="df", **kwargs):
+def matrix(df, xs=None, ys=None, output="df", **kwargs):
     """
     Calculate the Predictive Power Score (PPS) matrix for all columns in the dataframe
 
@@ -306,6 +306,8 @@ def matrix(df, output="df", **kwargs):
     ----------
     df : pandas.DataFrame
         The dataframe that contains the data
+    xs: list - Column names which act as features. Defaults to all columns in df
+    ys: list - Column names which act as targets. Defaults to all columns in df
     output: str - potential values: "df", "dict"
         Control the type of the output. Either return a df or a dict with all the PPS dicts arranged by the target column
     kwargs:
@@ -319,9 +321,27 @@ def matrix(df, output="df", **kwargs):
     data = {}
     columns = list(df.columns)
 
-    for target in columns:
+    if xs is None:
+        features = columns
+    else:
+        # check for key errors before computing the score matrix
+        for i in xs:
+            if i not in columns:
+                raise KeyError(i)
+        features = xs
+
+    if ys is None:
+        targets = columns
+    else:
+        # check for key errors before computing the score matrix
+        for i in ys:
+            if i not in columns:
+                raise KeyError(i)
+        targets = ys
+
+    for target in targets:
         scores = []
-        for feature in columns:
+        for feature in features:
             # single_score = score(df, x=feature, y=target)["ppscore"]
             try:
                 single_score = score(df, x=feature, y=target, **kwargs)["ppscore"]
@@ -333,7 +353,7 @@ def matrix(df, output="df", **kwargs):
 
     if output == "df":
         matrix = pd.DataFrame.from_dict(data, orient="index")
-        matrix.columns = columns
+        matrix.columns = features
         return matrix
     else:  # output == "dict"
         return data

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -103,3 +103,16 @@ def test_matrix():
     # matrix catches single score errors under the hood
     df["Age_datetime"] = pd.to_datetime(df["Age"], infer_datetime_format=True)
     assert pps.matrix(df[["Survived", "Age_datetime"]])["Survived"]["Age_datetime"] == 0
+
+    df = pd.read_csv("examples/titanic.csv")
+    df = df[["Age", "Sex", "Survived"]]
+
+    xs = ["Age", "Sex"]
+    ys = ["Survived"]
+
+    mat = pps.matrix(df, xs=xs, ys=ys)
+    # same values
+    assert mat["Age"]["Survived"] == pps.matrix(df[["Age", "Survived"]])["Age"]["Survived"]
+    # index and column names
+    assert all(i in mat.index for i in ys)
+    assert all(i in mat.columns for i in xs)


### PR DESCRIPTION
With ppscore taking a considerable amount of computation time, I thought this would be a handy feature for people working on very wide datasets.

added some simple tests to `test_matrix` in  `test_calculation.py`