### PR TITLE
Add predictors method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Based on the dataframe we can calculate the PPS of x predicting y:
 pps.score(df, "x", "y")
 ```
 
+We can calculate the PPS of all the predictors in the dataframe against a target y
+
+```python
+pps.predictors(df, "y")
+```
+
 Here is how we can calculate the PPS matrix between all columns:
 
 ```python
@@ -60,6 +66,15 @@ import seaborn as sns
 df_matrix = pps.matrix(df)
 sns.heatmap(df_matrix, vmin=0, vmax=1, cmap="Blues", linewidths=0.5, annot=True)
 ```
+
+Similarly, we can also plot the predictors
+
+```python
+import seaborn as sns
+df_predictors = pps.predictors(df, y="y")
+sns.barplot(data=df_predictors.reset_index(), x='index', y='ppscore')
+```
+
 
 
 ## API
@@ -98,6 +113,28 @@ Calculate the Predictive Power Score (PPS) for "x predicts y"
 - __Dict__:
     - A dict that contains multiple fields about the resulting PPS.
     The dict enables introspection into the calculations that have been performed under the hood
+
+
+### ppscore.predictors(df, y, output="df", sorted=True, **kwargs)
+
+Calculate the Predictive Power Score (PPS) for all columns in the dataframe against a target (y) column
+
+#### Parameters
+- __df__ : pandas.DataFrame
+    - The dataframe that contains the data
+- y : str
+    - Name of the column y which acts as the target
+- __output__ : str - potential values: "df", "list"
+    - Control the type of the output. Either return a df or a list with all the PPS score dicts
+- sorted : bool
+    - Whether or not to sort the output dataframe/list
+- __kwargs__ :
+    - Other key-word arguments that shall be forwarded to the pps.score method
+
+#### Returns
+
+- __pandas.DataFrame__ or list of PPS dict:
+    - Either returns a df or a list of all the PPS dicts. This can be influenced by the output argument
 
 
 ### ppscore.matrix(df, output="df", **kwargs)

--- a/src/ppscore/__init__.py
+++ b/src/ppscore/__init__.py
@@ -11,4 +11,11 @@ finally:
     del get_distribution, DistributionNotFound
 
 
-from ppscore.calculation import score, predictors, matrix, CV_ITERATIONS, RANDOM_SEED, NUMERIC_AS_CATEGORIC_BREAKPOINT
+from ppscore.calculation import (
+    score,
+    predictors,
+    matrix,
+    CV_ITERATIONS,
+    RANDOM_SEED,
+    NUMERIC_AS_CATEGORIC_BREAKPOINT,
+)

--- a/src/ppscore/__init__.py
+++ b/src/ppscore/__init__.py
@@ -11,4 +11,4 @@ finally:
     del get_distribution, DistributionNotFound
 
 
-from ppscore.calculation import score, matrix, CV_ITERATIONS, RANDOM_SEED, NUMERIC_AS_CATEGORIC_BREAKPOINT
+from ppscore.calculation import score, predictors, matrix, CV_ITERATIONS, RANDOM_SEED, NUMERIC_AS_CATEGORIC_BREAKPOINT

--- a/src/ppscore/calculation.py
+++ b/src/ppscore/calculation.py
@@ -294,8 +294,38 @@ def score(df, x, y, task=None, sample=5000):
     }
 
 
-# def predictors(df, y, task=None, sorted=True):
-#    pass
+def predictors(df, y, output="df", sorted=True, **kwargs):
+    """
+    Calculate the Predictive Power Score (PPS) of all the features in the dataframe against a target column
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The dataframe that contains the data
+    y : str
+        Name of the column y which acts as the target
+    output: str - potential values: "df", "list"
+        Control the type of the output. Either return a df or a dict with all the PPS dicts arranged by the feature columns in df
+    sorted: bool
+        Whether or not to sort the output dataframe
+    kwargs:
+        Other key-word arguments that shall be forwarded to the pps.score method
+
+    Returns
+    -------
+    pandas.DataFrame or list of Dict
+        Either returns a df or a list of all the PPS dicts. This can be influenced by the output argument
+    """
+    scores = [score(df, column, y, **kwargs) for column in df]
+
+    if sorted:
+        scores.sort(key=lambda item: item["ppscore"], reverse=True)
+
+    if output == 'df':
+        scores = {score['x']: score['ppscore'] for score in scores}
+        scores = pd.DataFrame.from_dict(scores, orient="index", columns=['ppscore'])
+
+    return scores
 
 
 def matrix(df, output="df", **kwargs):

--- a/src/ppscore/calculation.py
+++ b/src/ppscore/calculation.py
@@ -254,7 +254,9 @@ def score(df, x, y, task=None, sample=5000):
         # TODO: log.warning when values have been dropped
         df = df[[x, y]].dropna()
         if len(df) == 0:
-            raise Exception("After dropping missing values, there are no valid rows left")
+            raise Exception(
+                "After dropping missing values, there are no valid rows left"
+            )
         df = _maybe_sample(df, sample)
 
         if task is None:
@@ -321,9 +323,9 @@ def predictors(df, y, output="df", sorted=True, **kwargs):
     if sorted:
         scores.sort(key=lambda item: item["ppscore"], reverse=True)
 
-    if output == 'df':
-        scores = {score['x']: score['ppscore'] for score in scores}
-        scores = pd.DataFrame.from_dict(scores, orient="index", columns=['ppscore'])
+    if output == "df":
+        scores = {score["x"]: score["ppscore"] for score in scores}
+        scores = pd.DataFrame.from_dict(scores, orient="index", columns=["ppscore"])
 
     return scores
 

--- a/src/ppscore/calculation.py
+++ b/src/ppscore/calculation.py
@@ -321,7 +321,7 @@ def predictors(df, y, output="df", sorted=True, **kwargs):
         Either returns a df or a list of all the PPS dicts. This can be influenced
         by the output argument
     """
-    scores = [score(df, column, y, **kwargs) for column in df]
+    scores = [score(df, column, y, **kwargs) for column in df if column != y]
 
     if sorted:
         scores.sort(key=lambda item: item["ppscore"], reverse=True)

--- a/src/ppscore/calculation.py
+++ b/src/ppscore/calculation.py
@@ -298,7 +298,8 @@ def score(df, x, y, task=None, sample=5000):
 
 def predictors(df, y, output="df", sorted=True, **kwargs):
     """
-    Calculate the Predictive Power Score (PPS) of all the features in the dataframe against a target column
+    Calculate the Predictive Power Score (PPS) of all the features in the dataframe
+    against a target column
 
     Parameters
     ----------
@@ -307,7 +308,8 @@ def predictors(df, y, output="df", sorted=True, **kwargs):
     y : str
         Name of the column y which acts as the target
     output: str - potential values: "df", "list"
-        Control the type of the output. Either return a df or a dict with all the PPS dicts arranged by the feature columns in df
+        Control the type of the output. Either return a df or a dict with all the
+        PPS dicts arranged by the feature columns in df
     sorted: bool
         Whether or not to sort the output dataframe
     kwargs:
@@ -316,7 +318,8 @@ def predictors(df, y, output="df", sorted=True, **kwargs):
     Returns
     -------
     pandas.DataFrame or list of Dict
-        Either returns a df or a list of all the PPS dicts. This can be influenced by the output argument
+        Either returns a df or a list of all the PPS dicts. This can be influenced
+        by the output argument
     """
     scores = [score(df, column, y, **kwargs) for column in df]
 

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -94,10 +94,13 @@ def test_score():
 
 
 def test_predictors():
+    y = "Survived"
     df = pd.read_csv("examples/titanic.csv")
-    df = df[["Age", "Survived"]]
+    df = df[["Age", y]]
 
-    assert isinstance(pps.predictors(df, 'Survived'), pd.DataFrame)
+    result_df = pps.predictors(df, y)
+    assert isinstance(result_df, pd.DataFrame)
+    assert not y in result_df.index
     assert isinstance(pps.predictors(df, 'Survived', output="list"), list)
     assert isinstance(pps.predictors(df, 'Survived', output="list")[0], dict)  # return scores dict
 

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -93,6 +93,15 @@ def test_score():
     assert pps.score(df, "x_greater_0", "x")["ppscore"] < 0.6
 
 
+def test_predictors():
+    df = pd.read_csv("examples/titanic.csv")
+    df = df[["Age", "Survived"]]
+
+    assert isinstance(pps.predictors(df, 'Survived'), pd.DataFrame)
+    assert isinstance(pps.predictors(df, 'Survived', output="list"), list)
+    assert isinstance(pps.predictors(df, 'Survived', output="list")[0], dict)  # return scores dict
+
+
 def test_matrix():
     df = pd.read_csv("examples/titanic.csv")
     df = df[["Age", "Survived"]]


### PR DESCRIPTION
PR implements a `pps.predictors(df, y, output, sorted, **kwargs)` method to calculate the PPS of all the feature columns in the dataframe (predictors) against a target column (y). 

Method returns a dataframe or a list of dicts as returned by `pps.score` method

**Example:**
```python
>>> pps.predictors(titanic, y="Survived")
              ppscore
Survived     1.000000
Sex          0.593891
Fare         0.389189
Pclass       0.356068
Ticket       0.332686
SibSp        0.254135
Embarked     0.244262
Parch        0.197626
Age          0.185501
PassengerId  0.138689
Cabin        0.075921
Name         0.000000
```

Relevant issues/PR : #13 #14 