### PR TITLE
Parallel matrix calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
 ## [dev] (unreleased)
 - ...
+
+
+## [1.1.1]
+__Improvements:__
+- When installing `ppscore` automatically install dependencies. ([#29](https://github.com/8080labs/ppscore/issues/29))
+
 
 ## [1.1.0]
 __Default changes:__
@@ -12,6 +19,7 @@ __Default changes:__
 __Improvements:__
 - Improve error message when using the wrong API ([#31](https://github.com/8080labs/ppscore/issues/31))
 - Automatic error catching for convenience with optional error inspection/debugging: added `catch_errors` to `pps.score` and added corresponding case `unknown_error`
+
 
 ## [1.0.0]
 __Breaking changes:__

--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ In the following cases, the PPS is not defined and the score is set to `invalid_
 - __empty_dataframe_after_dropping_na__ occurs when there are no valid rows left after rows with missing values have been dropped. A possible solution might be to replace the missing values with valid values.
 - Last but not least, __unknown_error__ occurs for all other errors that might raise an exception. This case is only reported when `catch_errors` is `True`. If you want to inspect or debug the underlying error, please set `catch_errors` to `False`.
 
+## Citing ppscore
+[![DOI](https://zenodo.org/badge/256518683.svg)](https://zenodo.org/badge/latestdoi/256518683)
 
 ## About
 ppscore is developed by [8080 Labs](https://8080labs.com) - we create tools for Python Data Scientists. If you like `ppscore` you might want to check out our other project [bamboolib - a GUI for pandas DataFrames](https://bamboolib.com)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 
 [metadata]
 name = ppscore
-version = 1.1.0
+version = 1.1.1
 description = Python implementation of the Predictive Power Score (PPS)
 author = 8080 Labs, Florian Wetschoreck, Tobias Krabel
 author-email = info@8080labs.com

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import sys
 
 from pkg_resources import VersionConflict, require
 from setuptools import setup
+from pathlib import Path
 
 try:
     require("setuptools>=38.3")
@@ -19,5 +20,15 @@ except VersionConflict:
     sys.exit(1)
 
 
+def read_requirements(basename):
+    requirements_file = Path(__file__).parent.absolute() / basename
+    with open(requirements_file) as f:
+        return [req.strip() for req in f.readlines()]
+
+
 if __name__ == "__main__":
-    setup(use_pyscaffold=True)
+    requirements = read_requirements("requirements.txt")
+    setup(
+        use_pyscaffold=True,
+        install_requires=requirements
+    )

--- a/src/ppscore/calculation.py
+++ b/src/ppscore/calculation.py
@@ -2,7 +2,12 @@ from sklearn import tree
 from sklearn import preprocessing
 from sklearn.model_selection import cross_val_score
 from sklearn.metrics import mean_absolute_error, f1_score
+from itertools import product
+from tqdm import tqdm
+from functools import partial
+import multiprocessing as mp
 
+import numpy as np
 import pandas as pd
 from pandas.api.types import (
     is_numeric_dtype,
@@ -294,6 +299,15 @@ def _is_column_in_df(column, df):
         return False
 
 
+def get_random_seed(random_seed=None):
+    if random_seed is None:
+        from random import random
+
+        random_seed = int(random() * 1000)
+
+    return random_seed
+
+
 def _score(
     df, x, y, task, sample, cross_validation, random_seed, invalid_score, catch_errors
 ):
@@ -407,11 +421,6 @@ def score(
             "The attribute 'task' is no longer supported because it led to confusion and inconsistencies.\nThe task of the model is now determined based on the data types of the columns. If you want to change the task please adjust the data type of the column.\nFor more details, please refer to the README"
         )
 
-    if random_seed is None:
-        from random import random
-
-        random_seed = int(random() * 1000)
-
     try:
         return _score(
             df,
@@ -420,7 +429,7 @@ def score(
             task,
             sample,
             cross_validation,
-            random_seed,
+            get_random_seed(random_seed),
             invalid_score,
             catch_errors,
         )
@@ -459,6 +468,12 @@ def _get_task(case_type, invalid_score):
             "score_normalizer": None,
         }
     raise Exception(f"case_type {case_type} is not supported")
+
+
+# wrapper for multiprocessing
+def worker_wrapper(arg):
+    fun, args, kwargs = arg
+    return fun(*args, **kwargs)
 
 
 def _format_list_of_dicts(scores, output, sorted):
@@ -540,7 +555,15 @@ def predictors(df, y, output="df", sorted=True, **kwargs):
     return _format_list_of_dicts(scores=scores, output=output, sorted=sorted)
 
 
-def matrix(df, output="df", sorted=False, **kwargs):
+def _matrix(df, iterator, verbose=False, **kwargs):
+    if verbose:
+        iterator = tqdm(iterator, total=len(iterator))
+    scores = [score(df, x, y, **kwargs) for x, y in iterator]
+
+    return scores
+
+
+def matrix(df, output="df", sorted=False, verbose=True, n_jobs=1, presample=20_000, **kwargs):
     """
     Calculate the Predictive Power Score (PPS) matrix for all columns in the dataframe
 
@@ -552,6 +575,12 @@ def matrix(df, output="df", sorted=False, **kwargs):
         Control the type of the output. Either return a pandas.DataFrame (df) or a list with the score dicts
     sorted: bool
         Whether or not to sort the output dataframe/list by the ppscore
+    verbose: bool
+        tqdm bar for calculations
+    n_jobs: int
+        worker processes for calculations, -1 for all
+    presample: int
+        sampling for optimize parallel computing, affects only if n_jobs!=1
     kwargs:
         Other key-word arguments that shall be forwarded to the pps.score method,
         e.g. `sample, `cross_validation, `random_seed, `invalid_score`, `catch_errors`
@@ -575,6 +604,22 @@ def matrix(df, output="df", sorted=False, **kwargs):
             f"""The 'sorted' argument should be one of [True, False] but you passed: {sorted}\nPlease adjust your input to one of the valid values"""
         )
 
-    scores = [score(df, x, y, **kwargs) for x in df for y in df]
+    iterator = list(product(df.columns, df.columns))
+
+    if n_jobs == 1:
+        scores = _matrix(df, iterator, verbose=verbose, **kwargs)
+    else:
+        n_jobs = mp.cpu_count() if n_jobs == -1 else n_jobs
+
+        df = df.sample(min(presample, df.shape[0]),
+                       random_state=get_random_seed(kwargs.get("random_seed")))
+
+        with mp.Pool(n_jobs) as pool:
+            chunks = np.array_split(iterator, n_jobs)
+            pool_iterator = pool.starmap(
+                partial(_matrix, **kwargs),
+                [(df, chunk) for chunk in chunks]
+            )
+            scores = list(sum(pool_iterator, []))
 
     return _format_list_of_dicts(scores=scores, output=output, sorted=sorted)

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -259,7 +259,8 @@ def test_predictors():
     # the underlying calculations are tested as part of test_score
 
 
-def test_matrix():
+@pytest.mark.parametrize("n_jobs", [1, 2])
+def test_matrix(n_jobs):
     df = pd.read_csv("examples/titanic.csv")
     df = df[["Age", "Survived"]]
     df["Age_datetime"] = pd.to_datetime(df["Age"], infer_datetime_format=True)
@@ -268,19 +269,19 @@ def test_matrix():
     # check input types
     with pytest.raises(TypeError):
         numpy_array = np.random.randn(10, 10)  # not a DataFrame
-        pps.matrix(numpy_array)
+        pps.matrix(numpy_array, n_jobs=n_jobs)
 
     with pytest.raises(ValueError):
-        pps.matrix(df, output="invalid_output_type")
+        pps.matrix(df, output="invalid_output_type", n_jobs=n_jobs)
 
     # check return types
-    assert isinstance(pps.matrix(df), pd.DataFrame)
-    assert isinstance(pps.matrix(df, output="list"), list)
+    assert isinstance(pps.matrix(df, n_jobs=n_jobs), pd.DataFrame)
+    assert isinstance(pps.matrix(df, output="list", n_jobs=n_jobs), list)
 
     # matrix catches single score errors under the hood
     invalid_score = [
         score
-        for score in pps.matrix(subset_df, output="list")
+        for score in pps.matrix(subset_df, output="list", n_jobs=n_jobs)
         if (score["x"] == "Survived" and score["y"] == "Age_datetime")
     ][0]
     assert invalid_score["ppscore"] == 0


### PR DESCRIPTION
Add paralleling compurations for pps.matrix. In my sample test data with 20 columns on 8CPU machine boost from 21 second to 5.7.
But for data with a lot of columns(>60) still too slow. I have idea to add parameter for selection only interesting columns from data(maybe interesting for specific column) and optimize calculations for data with a large number of columns. Also it will be usefull for better matrix understanding.