### PR TITLE
Bump Scikit version (Issue #53)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pandas>=1.0.0,<2.0.0
-scikit-learn>=0.20.2,<1.0.0
+scikit-learn>=0.20.2,<1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pandas>=1.0.0,<2.0.0
-scikit-learn>=0.20.2,<1.0.0
+scikit-learn>=0.20.2,<1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pandas>=1.0.0,<2.0.0
-scikit-learn>=0.20.2,<1.1
+scikit-learn>=0.20.2,<1.0.0


### PR DESCRIPTION
Ran the tests and all passed. One future warning from scikit for version 1.1:
```
FutureWarning: Arrays of bytes/strings is being converted to decimal numbers if dtype='numeric'. This behavior is deprecated in 0.24 and will be removed in 1.1 (renaming of 0.26). Please convert your data to numeric values explicitly instead.
y_true = check_array(y_true, ensure_2d=False, dtype=dtype)
```